### PR TITLE
Fix breaking migration

### DIFF
--- a/database/migrations/2020_02_03_205615_oops.php
+++ b/database/migrations/2020_02_03_205615_oops.php
@@ -14,7 +14,7 @@ class Oops extends Migration
     public function up()
     {
         Schema::table('lineups', function (Blueprint $table) {
-            $table->integer('player_id');
+            $table->integer('player_id')->nullable();;
         });
     }
 


### PR DESCRIPTION
This migration seemingly fixes a prior migration issue, but on a fresh
run, it's the one that breaks:

    > php artisan migrate

    Migrating: 2020_02_03_205615_oops

       Illuminate\Database\QueryException  : SQLSTATE[HY000]: General
       error: 1 Cannot add a NOT NULL column with default value NULL
       (SQL: alter table "lineups" add column "player_id" integer not null)