### PR TITLE
Modify Seeder to seed from dump file

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,7 +11,12 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
-        $this->call(PostSeeder::class);
+        Eloquent::unguard();
+        $memory_limit = ini_get('memory_limit');
+        ini_set('memory_limit', '-1');
+        DB::unprepared(file_get_contents(
+          'database/seeds/dev-snapshot.sql'));
+        ini_set('memory_limit', $memory_limit);
+        $this->command->info('Example database loaded!');
     }
 }


### PR DESCRIPTION
Allows seeding the database via `php artisan db:seed`. Assumes the SQL-LITE dump exists from `database/seeds/dev-snapshot.sql` per #105 

Feel free to change the path/naming per your preference.